### PR TITLE
[Bug fix] Use specified index instead of alias when exact name is spe…

### DIFF
--- a/es-reindexers/elastic-reindex.sh
+++ b/es-reindexers/elastic-reindex.sh
@@ -15,6 +15,11 @@ check_destination_variables() {
 
 alias=$SOURCE_INDEX
 indices=$(curl -s -X GET $SOURCE_ES'/_alias/'$SOURCE_INDEX | jq -r 'keys[0]')
+if [ "$indices" = "error" ]; then
+  index_prefix="$SOURCE_INDEX"
+else
+  index_prefix="${indices%%-[0-9]*}"
+fi
 index_prefix=${indices%-[0-9]*}
 all_indices=$(curl -s -X GET $SOURCE_ES'/_cat/indices/'$index_prefix'*?format=json')
 sorted_indices=$(echo "$all_indices" | jq -r '.[] | .index' | sort -r)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Use exact source index name when specified. Written a logic that automatically detects and identifies source index when either of the alias or index name are specified.

## Related Tickets & Documents

**Related Issue:** Came across an issue while performing initial backup on one of our ripsaw-kube-buner-* indices. The script was failing to detect index when exact name like `ripsaw-kube-burner-000020` was specified. It was trying to interpret as alias and was trying search for indices. So this PR corrects that logic to correctly identify it the specified `$SOURCE_INDEX` env is an index or alias and act accordingly.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested on the jump host and verified that the script was running successfully. Followed the steps in the repo's README.md to run a test.
